### PR TITLE
Allow resetting codes, cleanup, fixes

### DIFF
--- a/SpecialScratchLogin.php
+++ b/SpecialScratchLogin.php
@@ -1,31 +1,44 @@
 <?php
+define('API_URL', 'https://api.scratch.mit.edu/users/%s/projects/%s/comments?offset=0&limit=20');
+define('PROJECT_LINK', 'https://scratch.mit.edu/projects/%s/');
+
 function sessionVerificationCode(&$session) {
 	if ($session->exists('vercode')) {
 		return $session->get('vercode');
 	} else {
 		$session->persist();
-		$session->set('vercode', sha1(rand()));
+		$session->set('vercode', hash('sha256', random_bytes(16)));
 		$session->save();
 		return $session->get('vercode');
 	}
 }
 
-function getComments($project_id) {
-	return json_decode(file_get_contents('https://api.scratch.mit.edu/users/ModShare/projects/10135908/comments?offset=0&limit=20'));
+function getComments() {
+	return json_decode(file_get_contents(sprintf(
+		API_URL, wfMessage('scratchlogin-project-author')->text(),
+		wfMessage('scratchlogin-project-id')->text()
+	)), TRUE);
 }
 
-function commenter($project_id, $req_comment) {
-	$comments = getComments($project_id);
+function commenter($req_comment) {
+	$comments = getComments();
 	
-	$matching_comments = array_filter($comments, function(&$comment) use($req_comment) { return stristr((string)$comment->content, (string)$req_comment); });
-	return empty($matching_comments) ?
-		null :
-		(string)$matching_comments[0]->author->username;
+	$matching_comments = array_filter($comments, function(&$comment) use($req_comment) {
+		return stristr($comment['content'], $req_comment);
+	});
+	if (empty($matching_comments)) {
+		return null;
+	}
+	return $matching_comments[0]['author']['username'];
 }
 
 class SpecialScratchLogin extends SpecialPage {
 	function __construct() {
 		parent::__construct('ScratchLogin');
+	}
+	
+	function getGroupName() {
+		return 'login';
 	}
 	
 	function execute($par) {
@@ -36,7 +49,7 @@ class SpecialScratchLogin extends SpecialPage {
 		if ($request->wasPosted()) {
 			self::onPost( $par, $out, $request );
 		} else {
-			self::loginForm($par, $out, $request);
+			self::loginForm( $par, $out, $request );
 		}
 	}
 	
@@ -46,14 +59,23 @@ class SpecialScratchLogin extends SpecialPage {
 				[ 'method' => 'POST' ]
 		));
 		
-		$out->addHTML('<p>You need to enter the following verification code on the <a href="https://scratch.mit.edu/projects/10135908/" target="_blank">user verification project</a>: <br /><b>' . sessionVerificationCode($request->getSession()) . '</b></p>');
+		$link = Html::openElement('a', [
+			'href' => sprintf(PROJECT_LINK, wfMessage('scratchlogin-project-id')->text()),
+			'target' => '_blank'
+		]);
+		
+		$out->addHTML(wfMessage(
+			'scratchlogin-instructions',
+			$link, Html::closeElement( 'a' ),
+			sessionVerificationCode($request->getSession())
+		)->inContentLanguage()->parseAsBlock());
 				
 		$out->addHTML(Html::rawElement(
 			'input',
 			[
 				'type' => 'submit',
 				'id' => 'mw-scratchlogin-form-submit',
-				'value' => 'Log in'
+				'value' => wfMessage('login')->inContentLangauge()->plain()
 			]
 		));
 		
@@ -61,23 +83,31 @@ class SpecialScratchLogin extends SpecialPage {
 	}
 	
 	private static function showError($error, $par, $out, $request) {
-		$out->addHTML('<p>' . $error . '</p>');
+		$out->addHTML(Html::rawElement('p', [ 'class' => 'error' ], $error));
 		self::loginForm($par, $out, $request);
 	}
 	
 	private static function onPost( $par, $out, $request ) {
 		global $wgSecureLogin;
 		
-		$username = commenter('', sessionVerificationCode($request->getSession()));
+		$username = commenter(sessionVerificationCode($request->getSession()));
 		
 		if ($username == null) {
-			self::showError('You do not appear to have comented the code on the project.', $par, $out, $request);
+			self::showError(
+				wfMessage('scratchlogin-uncommented')
+				->inContentLangauge()->plain(),
+				$par, $out, $request
+			);
 			return;
 		}
 						
 		$user = User::newFromName($username);
 		if ($user->getId() == 0) {
-			self::showError('The user <b>' . $username . '</b> is not registered on this wiki', $par, $out, $request);
+			self::showError(
+				wfMessage('scratchlogin-unregistered', $username)
+				->inContentLangauge()->parse(),
+				$par, $out, $request
+			);
 			return;
 		}
 		
@@ -85,6 +115,6 @@ class SpecialScratchLogin extends SpecialPage {
 		$request->getSession()->setUser($user);
 		$request->getSession()->save();
 		
-		$out->addHTML('<p>Success! You are now logged in as <b>' . $username . '</b></p>');
+		$out->addWikiMsg('scratchlogin-success', $username);
 	}
 }

--- a/SpecialScratchLogin.php
+++ b/SpecialScratchLogin.php
@@ -2,15 +2,17 @@
 define('API_URL', 'https://api.scratch.mit.edu/users/%s/projects/%s/comments?offset=0&limit=20');
 define('PROJECT_LINK', 'https://scratch.mit.edu/projects/%s/');
 
+function setCode(&$session) {
+	$session->persist();
+	$session->set('vercode', strtr(hash('sha256', random_bytes(16)), '0123456789', 'ABCDEFGHIJ'));
+	$session->save();
+}
+
 function sessionVerificationCode(&$session) {
-	if ($session->exists('vercode')) {
-		return $session->get('vercode');
-	} else {
-		$session->persist();
-		$session->set('vercode', hash('sha256', random_bytes(16)));
-		$session->save();
-		return $session->get('vercode');
+	if (!$session->exists('vercode')) {
+		setCode($session);
 	}
+	return $session->get('vercode');
 }
 
 function getComments() {
@@ -22,7 +24,7 @@ function getComments() {
 
 function commenter($req_comment) {
 	$comments = getComments();
-	
+
 	$matching_comments = array_filter($comments, function(&$comment) use($req_comment) {
 		return stristr($comment['content'], $req_comment);
 	});
@@ -36,85 +38,89 @@ class SpecialScratchLogin extends SpecialPage {
 	function __construct() {
 		parent::__construct('ScratchLogin');
 	}
-	
+
 	function getGroupName() {
 		return 'login';
 	}
-	
+
 	function execute($par) {
 		$request = $this->getRequest();
 		$out = $this->getOutput();
 		$this->setHeaders();
-		
-		if ($request->wasPosted()) {
+
+		if ($par == 'reset') {
+			self::resetCode( $par, $out, $request );
+		} else if ($request->wasPosted()) {
 			self::onPost( $par, $out, $request );
 		} else {
 			self::loginForm( $par, $out, $request );
 		}
 	}
-	
+
 	static private function loginForm($par, $out, $request) {
 		$out->addHTML(Html::openElement(
 				'form',
 				[ 'method' => 'POST' ]
 		));
-		
+
 		$link = Html::openElement('a', [
 			'href' => sprintf(PROJECT_LINK, wfMessage('scratchlogin-project-id')->text()),
 			'target' => '_blank'
 		]);
-		
-		$out->addHTML(wfMessage(
-			'scratchlogin-instructions',
+
+		$out->addHTML(wfMessage('scratchlogin-instructions')->rawParams(
 			$link, Html::closeElement( 'a' ),
 			sessionVerificationCode($request->getSession())
 		)->inContentLanguage()->parseAsBlock());
-				
+
 		$out->addHTML(Html::rawElement(
 			'input',
 			[
 				'type' => 'submit',
 				'id' => 'mw-scratchlogin-form-submit',
-				'value' => wfMessage('login')->inContentLangauge()->plain()
+				'value' => wfMessage('login')->inContentLanguage()->plain()
 			]
 		));
-		
+
 		$out->addHTML(Html::closeElement( 'form' ));
 	}
-	
+
 	private static function showError($error, $par, $out, $request) {
 		$out->addHTML(Html::rawElement('p', [ 'class' => 'error' ], $error));
 		self::loginForm($par, $out, $request);
 	}
-	
+
 	private static function onPost( $par, $out, $request ) {
-		global $wgSecureLogin;
-		
 		$username = commenter(sessionVerificationCode($request->getSession()));
-		
+
 		if ($username == null) {
 			self::showError(
 				wfMessage('scratchlogin-uncommented')
-				->inContentLangauge()->plain(),
+				->inContentLanguage()->plain(),
 				$par, $out, $request
 			);
 			return;
 		}
-						
+
 		$user = User::newFromName($username);
 		if ($user->getId() == 0) {
 			self::showError(
 				wfMessage('scratchlogin-unregistered', $username)
-				->inContentLangauge()->parse(),
+				->inContentLanguage()->parse(),
 				$par, $out, $request
 			);
 			return;
 		}
-		
+
 		$request->getSession()->clear('vercode');
 		$request->getSession()->setUser($user);
 		$request->getSession()->save();
-		
+
 		$out->addWikiMsg('scratchlogin-success', $username);
+	}
+
+	private static function resetCode( $par, $out, $request) {
+		setCode($request->getSession());
+		$out->addWikiMsg('scratchlogin-code-reset');
 	}
 }

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
 	"name": "Scratch Login",
-	"author": ["Jacob G. (jvvg)"],
-	"url": "https://www.mediawiki.org/wiki/Extension:Example",
+	"author": ["Jacob G. (jvvg)", "Kenny2scratch"],
+	"url": "https://github.com/jacob-g/mediawiki-scratch-login",
 	"descriptionmsg": "scratchlogin-desc",
 	"version": "1.0",
 	"license-name": "GPL-2.0-or-later",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -11,8 +11,9 @@
 	"scratchlogin-summary": "Log in with your Scratch account.",
 	"scratchlogin-project-id": "10135908",
 	"scratchlogin-project-author": "ModShare",
-	"scratchlogin-instructions": "Please comment the following verification code on the $1user verification project$2:<br/>'''$3'''",
+	"scratchlogin-instructions": "Please comment the following verification code on the $1user verification project$2:<br/>'''$3'''<br/><small>(If necessary, you can [[Special:ScratchLogin/reset|reset your verification code]].)",
 	"scratchlogin-uncommented": "You do not appear to have commented the code on the project.",
 	"scratchlogin-unregistered": "The user '''$1''' is not registered on this wiki.",
-	"scratchlogin-success": "Success! You are now logged in as '''$1'''."
+	"scratchlogin-success": "Success! You will be logged in as '''$1''' on the next page you visit.",
+	"scratchlogin-code-reset": "Your verification code has been reset.<br/>Return to [[Special:ScratchLogin]]."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,12 +1,18 @@
 {
 	"@metadata": {
 		"authors": [
-			"jvvg"
+			"jvvg",
+			"Kenny2scratch"
 		]
 	},
 	"scratchlogin": "Scratch Login",
-	"scratchlogin-desc": "Log in with your Scratch account",
-	"scratchlogin-title": "Log in with your Scratch account",
-	"scratchlogin-summary": "Go here to log in with your Scratch account",
-	"action-scratchlogin": ""
+	"scratchlogin-desc": "Allows logging in with a Scratch account.",
+	"scratchlogin-title": "Log in with Scratch",
+	"scratchlogin-summary": "Log in with your Scratch account.",
+	"scratchlogin-project-id": "10135908",
+	"scratchlogin-project-author": "ModShare",
+	"scratchlogin-instructions": "Please comment the following verification code on the $1user verification project$2:<br/>'''$3'''",
+	"scratchlogin-uncommented": "You do not appear to have commented the code on the project.",
+	"scratchlogin-unregistered": "The user '''$1''' is not registered on this wiki.",
+	"scratchlogin-success": "Success! You are now logged in as '''$1'''."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1,12 +1,18 @@
 {
 	"@metadata": {
 		"authors": [
-			"jvvg"
+			"jvvg",
+			"Kenny2scratch"
 		]
 	},
-	"scratchlogin": "Log in with a Scratch account",
-	"scratchlogin-desc": "some description",
-	"scratchlogin-summary": "ScratchLogin summary",
-	"scratchlogin-title": "Title",
-	"action-scratchlogin": ""
+	"scratchlogin": "The name of the extension in [[Special:SpecialPages]]",
+	"scratchlogin-desc": "Description shown on Special:Version",
+	"scratchlogin-title": "Title of extension",
+	"scratchlogin-summary": "Description shown on [[Special:ScratchLogin]]",
+	"scratchlogin-project-id": "ID of verification project",
+	"scratchlogin-project-author": "Author of verification project",
+	"scratchlogin-instructions": "Instructions shown on [[Special:ScratchLogin]]. $1 and $2 open and close the link to the project; $3 is the verification code.",
+	"scratchlogin-uncommented": "Error message when the code is not found.",
+	"scratchlogin-unregistered": "Error message when the user who commented the code is not registered on the wiki. $1 is the username found.",
+	"scratchlogin-success": "Message for successful login. $1 is the logged in username."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -14,5 +14,6 @@
 	"scratchlogin-instructions": "Instructions shown on [[Special:ScratchLogin]]. $1 and $2 open and close the link to the project; $3 is the verification code.",
 	"scratchlogin-uncommented": "Error message when the code is not found.",
 	"scratchlogin-unregistered": "Error message when the user who commented the code is not registered on the wiki. $1 is the username found.",
-	"scratchlogin-success": "Message for successful login. $1 is the logged in username."
+	"scratchlogin-success": "Message for successful login. $1 is the logged in username.",
+	"scratchlogin-code-reset": "Message for successful reset of verification code."
 }


### PR DESCRIPTION
* Changed all hardcoded text to `wfMessage` strings
* Verification code bypasses Scratch phone number censor by translating digits into capital letters
* Added the ability to reset verification codes by going to Special:ScratchLogin/reset
* Generally cleaned up code and i18n files