### PR TITLE
Fix deprecations

### DIFF
--- a/ScratchLogin.common.php
+++ b/ScratchLogin.common.php
@@ -155,7 +155,7 @@ class ScratchSpecialPage extends SpecialPage {
 			//in the event of any failure, do NOT allow the login attempt to continue
 
 			$this->showError(wfMessage('scratchlogin-api-failure')->inContentLanguage()->parse(), $out, $request);
-			$logger->error('Error while checking registration time: {exc}', ['exc' => $e]);
+			$logger->error('Error while checking registration time: {exception}', ['exception' => $e]);
 
 			return null;
 		}

--- a/ScratchLogin.common.php
+++ b/ScratchLogin.common.php
@@ -101,7 +101,7 @@ class ScratchSpecialPage extends SpecialPage {
 		if ($username == null) {
 			$this->showError(
 				$authenticator::getMissingMsg($this)
-				->inContentLanguage()->plain(),
+				->inContentLanguage()->parse(),
 				$out, $request
 			);
 			return null;

--- a/ScratchLogin.common.php
+++ b/ScratchLogin.common.php
@@ -1,4 +1,7 @@
 <?php
+
+use MediaWiki\User\UserFactory;
+use MediaWiki\Logger\LoggerFactory;
 use Wikimedia\Timestamp\ConvertibleTimestamp;
 
 define('USER_API_LINK', 'https://api.scratch.mit.edu/users/%s/');
@@ -7,17 +10,18 @@ function getAuthenticator() {
 	global $wgScratchLoginAuthenticator;
 	switch ($wgScratchLoginAuthenticator) {
 		case 'cloud': {
-			return ScratchLogin\Authenticator\CloudVariableAuthenticator::class;
-		}
+				return ScratchLogin\Authenticator\CloudVariableAuthenticator::class;
+			}
 		default: {
-			return ScratchLogin\Authenticator\ProjectCommentAuthenticator::class;
-		}
+				return ScratchLogin\Authenticator\ProjectCommentAuthenticator::class;
+			}
 	}
 }
 
 function getScratchUserRegisteredAt($username) {
 	$apiText = file_get_contents(sprintf(
-		USER_API_LINK, $username
+		USER_API_LINK,
+		$username
 	));
 
 	//fail loudly if the API call fails
@@ -37,6 +41,13 @@ function getScratchUserRegisteredAt($username) {
 }
 
 class ScratchSpecialPage extends SpecialPage {
+	private UserFactory $userFactory;
+
+	function __construct(string $title, UserFactory $userFactory) {
+		parent::__construct($title);
+		$this->userFactory = $userFactory;
+	}
+
 
 	function execute($par) {
 		$request = $this->getRequest();
@@ -45,18 +56,18 @@ class ScratchSpecialPage extends SpecialPage {
 		$this->setHeaders();
 		$this->checkReadOnly();
 
-		if ($par == 'reset') {
-			$this->resetCode( $out, $request );
+		if ($par === 'reset') {
+			$this->resetCode($out, $request);
 		} else if ($request->wasPosted()) {
-			$this->onPost( $out, $request );
+			$this->onPost($out, $request);
 		} else {
-			$this->showForm( $out, $request );
+			$this->showForm($out, $request);
 		}
 	}
 
 	// show an error followed by the login form again
 	function showError($error, $out, $request) {
-		$out->addHTML(Html::rawElement('p', [ 'class' => 'error' ], $error));
+		$out->addHTML(Html::rawElement('p', ['class' => 'error'], $error));
 		$this->showForm($out, $request);
 	}
 
@@ -67,8 +78,8 @@ class ScratchSpecialPage extends SpecialPage {
 
 		// this all takes place in a form
 		$out->addHTML(Html::openElement(
-				'form',
-				[ 'method' => 'POST' ]
+			'form',
+			['method' => 'POST']
 		));
 
 		$session = $request->getSession();
@@ -80,7 +91,7 @@ class ScratchSpecialPage extends SpecialPage {
 		)->inContentLanguage()->parseAsBlock());
 
 		// show the submit button
-		$out->addHTML(Html::rawElement(
+		$out->addHTML(Html::element(
 			'input',
 			[
 				'type' => 'submit',
@@ -90,34 +101,37 @@ class ScratchSpecialPage extends SpecialPage {
 		));
 
 		//close the form
-		$out->addHTML(Html::closeElement( 'form' ));
+		$out->addHTML(Html::closeElement('form'));
 	}
 
 	function verifSucceeded($out, $request) {
+		$logger = LoggerFactory::getInstance('SpecialScratchLogin');
 		$session = $request->getSession();
 		$authenticator = getAuthenticator();
 		$username = $authenticator::getAssociatedUsername($session, $this);
 
-		if ($username == null) {
+		if ($username === null) {
 			$this->showError(
 				$authenticator::getMissingMsg($this)
-				->inContentLanguage()->parse(),
-				$out, $request
+					->inContentLanguage()->parse(),
+				$out,
+				$request
 			);
 			return null;
 		}
 
 		// now attempt to retrieve the MediaWiki user
 		// associated with whoever commented the verification code
-		$user = User::newFromName($username);
+		$user = $this->userFactory->newFromName($username);
 
 		// ...if that user does not exist, then show an error
 		// that this account does not exist on the wiki
-		if ($user->getId() == 0) {
+		if (!$user->isRegistered()) {
 			$this->showError(
 				wfMessage('scratchlogin-unregistered', $username)
-				->inContentLanguage()->parse(),
-				$out, $request
+					->inContentLanguage()->parse(),
+				$out,
+				$request
 			);
 			return null;
 		}
@@ -131,8 +145,9 @@ class ScratchSpecialPage extends SpecialPage {
 				// To prevent disaster, make it error.
 				$this->showError(
 					wfMessage('scratchlogin-account-age-error', $username)
-					->inContentLanguage()->parse(),
-					$out, $request
+						->inContentLanguage()->parse(),
+					$out,
+					$request
 				);
 				return null;
 			}
@@ -140,6 +155,7 @@ class ScratchSpecialPage extends SpecialPage {
 			//in the event of any failure, do NOT allow the login attempt to continue
 
 			$this->showError(wfMessage('scratchlogin-api-failure')->inContentLanguage()->parse(), $out, $request);
+			$logger->error('Error while checking registration time: {exc}', ['exc' => $e]);
 
 			return null;
 		}

--- a/ScratchLogin.hooks.php
+++ b/ScratchLogin.hooks.php
@@ -1,22 +1,21 @@
 <?php
 
-class ScratchLoginHooks {
+use MediaWiki\Hook\BeforePageDisplayHook;
+
+class ScratchLoginHooks implements BeforePageDisplayHook {
 	// add a link to login with Scratch after the login page
 	// hook name that calls this is BeforePageDisplay
-	static public function insertScratchLoginLink( &$out, &$skin ) {
+	public function onBeforePageDisplay($out, $skin) : void {
 		$title = $out->getContext()->getTitle();
 		// this hook is called on all pages,
 		// so check that we're on the right Special page
-		if ($title->isSpecial( 'Userlogin' )) {
+		if ($title->isSpecial('Userlogin')) {
 			// link to Special:ScratchLogin on Special:UserLogin
 			$out->addWikiMsg('scratchlogin-userlogin-link');
-			return true;
 		}
-		if ($title->isSpecial( 'PasswordReset' )) {
+		if ($title->isSpecial('PasswordReset')) {
 			// link to Special:ScratchPasswordReset on Special:PasswordReset
-			$out->addWikimsg('scratchpasswordreset-passwordreset-link');
-			return true;
+			$out->addWikiMsg('scratchpasswordreset-passwordreset-link');
 		}
-		return true;
 	}
 }

--- a/SpecialScratchLogin.php
+++ b/SpecialScratchLogin.php
@@ -1,9 +1,11 @@
 <?php
 require_once __DIR__ . '/ScratchLogin.common.php';
 
+use MediaWiki\User\UserFactory;
+
 class SpecialScratchLogin extends ScratchSpecialPage {
-	function __construct() {
-		parent::__construct('ScratchLogin');
+	function __construct(UserFactory $userFactory) {
+		parent::__construct('ScratchLogin', $userFactory);
 	}
 
 	function getGroupName() {

--- a/SpecialScratchLogin.php
+++ b/SpecialScratchLogin.php
@@ -22,7 +22,7 @@ class SpecialScratchLogin extends ScratchSpecialPage {
 		// this handles all of the error message showing
 		// and returns null if failed
 		$user = $this->verifSucceeded($out, $request);
-		if ($user == null) return;
+		if ($user === null) return;
 		// now that we have passed all the other hurdles, log in the user
 		// set the logged in user to the user found by that name
 		$request->getSession()->setUser($user);

--- a/SpecialScratchPasswordReset.php
+++ b/SpecialScratchPasswordReset.php
@@ -3,10 +3,11 @@ require_once __DIR__ . '/ScratchLogin.common.php';
 
 use MediaWiki\Auth\TemporaryPasswordAuthenticationRequest;
 use MediaWiki\Auth\AuthManager;
+use MediaWiki\User\UserFactory;
 
 class SpecialScratchPasswordReset extends ScratchSpecialPage {
-	function __construct() {
-		parent::__construct('ScratchPasswordReset');
+	function __construct(UserFactory $userFactory) {
+		parent::__construct('ScratchPasswordReset', $userFactory);
 	}
 
 	function getGroupName() {

--- a/SpecialScratchPasswordReset.php
+++ b/SpecialScratchPasswordReset.php
@@ -6,8 +6,11 @@ use MediaWiki\Auth\AuthManager;
 use MediaWiki\User\UserFactory;
 
 class SpecialScratchPasswordReset extends ScratchSpecialPage {
-	function __construct(UserFactory $userFactory) {
+	private AuthManager $authManager;
+
+	function __construct(UserFactory $userFactory, AuthManager $authManager) {
 		parent::__construct('ScratchPasswordReset', $userFactory);
+		$this->authManager = $authManager;
 	}
 
 	function getGroupName() {
@@ -17,7 +20,8 @@ class SpecialScratchPasswordReset extends ScratchSpecialPage {
 	function showForm($out, $request) {
 		// show the verification form with pwreset instructions and "Verify" button
 		$this->verifForm(
-			$out, $request,
+			$out,
+			$request,
 			'passwordreset',
 			'scratchpasswordreset-verify'
 		);
@@ -26,7 +30,7 @@ class SpecialScratchPasswordReset extends ScratchSpecialPage {
 	function onPost($out, $request) {
 		// this shows errors if verif failed
 		$user = $this->verifSucceeded($out, $request);
-		if ($user == null) return;
+		if ($user === null) return;
 		// do the password reset, all has been checked
 		// create a new auth request to set a temporary password
 		$req = TemporaryPasswordAuthenticationRequest::newRandom();
@@ -35,7 +39,7 @@ class SpecialScratchPasswordReset extends ScratchSpecialPage {
 		// this needs to be set for changeAuthenticationData
 		$req->username = $user->getName();
 		// use the global AuthManager to submit the auth request
-		AuthManager::singleton()->changeAuthenticationData($req);
+		$this->authManager->changeAuthenticationData($req);
 		// display the password and pass the username to log in with
 		$out->addWikiMsg('scratchpasswordreset-success', $req->password, $user->getName());
 	}

--- a/authenticator/Authenticator.php
+++ b/authenticator/Authenticator.php
@@ -56,7 +56,7 @@ abstract class Authenticator {
 			throw new Exception($err);
 		}
 		$statusCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
-		if ($statusCode != 200) {
+		if ($statusCode !== 200) {
 			curl_close($ch);
 			throw new Exception("Authenticator::get failed while querying $url: status code $statusCode");
 		}

--- a/extension.json
+++ b/extension.json
@@ -23,8 +23,18 @@
 		"ScratchLogin\\Authenticator\\": "./authenticator/"
 	},
 	"SpecialPages": {
-		"ScratchLogin": "SpecialScratchLogin",
-		"ScratchPasswordReset": "SpecialScratchPasswordReset"
+		"ScratchLogin": {
+			"class": "SpecialScratchLogin",
+			"services": [
+				"UserFactory"
+			]
+		},
+		"ScratchPasswordReset": {
+			"class": "SpecialScratchPasswordReset",
+			"services": [
+				"UserFactory"
+			]
+		}
 	},
 	"Hooks": {
 		"BeforePageDisplay": "main"

--- a/extension.json
+++ b/extension.json
@@ -32,7 +32,8 @@
 		"ScratchPasswordReset": {
 			"class": "SpecialScratchPasswordReset",
 			"services": [
-				"UserFactory"
+				"UserFactory",
+				"AuthManager"
 			]
 		}
 	},

--- a/extension.json
+++ b/extension.json
@@ -6,7 +6,7 @@
 	],
 	"url": "https://github.com/jacob-g/mediawiki-scratch-login",
 	"descriptionmsg": "scratchlogin-desc",
-	"version": "1.1",
+	"version": "2.0",
 	"license-name": "GPL-2.0-or-later",
 	"type": "specialpage",
 	"MessagesDirs": {

--- a/extension.json
+++ b/extension.json
@@ -1,14 +1,18 @@
 {
 	"name": "Scratch Login",
-	"author": ["Jacob G. (jvvg)", "Kenny2scratch"],
+	"author": [
+		"Jacob G. (jvvg)",
+		"Kenny2scratch"
+	],
 	"url": "https://github.com/jacob-g/mediawiki-scratch-login",
 	"descriptionmsg": "scratchlogin-desc",
 	"version": "1.1",
 	"license-name": "GPL-2.0-or-later",
 	"type": "specialpage",
-	"manifest_version": 1,
 	"MessagesDirs": {
-		"ScratchLogin": ["i18n"]
+		"ScratchLogin": [
+			"i18n"
+		]
 	},
 	"AutoloadClasses": {
 		"SpecialScratchLogin": "SpecialScratchLogin.php",
@@ -23,12 +27,22 @@
 		"ScratchPasswordReset": "SpecialScratchPasswordReset"
 	},
 	"Hooks": {
-		"BeforePageDisplay": "ScratchLoginHooks::insertScratchLoginLink"
+		"BeforePageDisplay": "main"
+	},
+	"HookHandlers": {
+		"main": {
+			"class": "ScratchLoginHooks"
+		}
 	},
 	"config": {
 		"ScratchLoginAuthenticator": {
-			"value": "project"
+			"value": {
+				"value": "project"
+			}
 		}
 	},
-	"manifest_version": 2
+	"manifest_version": 2,
+	"requires": {
+		"MediaWiki": ">= 1.35.0"
+	}
 }


### PR DESCRIPTION
Contains fix for CVE-2022-42985: The ScratchLogin extension through 1.1 for MediaWiki does not escape verification failure messages, which allows users with administrator privileges to perform cross-site scripting (XSS).